### PR TITLE
feat: Implements support for custom SAML -> OIDC mappings

### DIFF
--- a/sweden-connect-provider/src/main/java/se/swedenconnect/keycloak/oidc/AttributeClaim.java
+++ b/sweden-connect-provider/src/main/java/se/swedenconnect/keycloak/oidc/AttributeClaim.java
@@ -25,30 +25,18 @@ package se.swedenconnect.keycloak.oidc;
 public class AttributeClaim {
   private final String samlAttributeName;
   private final String oidcClaimName;
-  private final Boolean idToken;
-  private final Boolean accessToken;
-  private final Boolean userInfo;
 
   /**
    * Constructor.
    * @param samlAttributeName
    * @param oidcClaimName
-   * @param idToken
-   * @param accessToken
-   * @param userInfo
    */
   public AttributeClaim(
       final String samlAttributeName,
-      final String oidcClaimName,
-      final Boolean idToken,
-      final Boolean accessToken,
-      final Boolean userInfo) {
+      final String oidcClaimName) {
 
     this.samlAttributeName = samlAttributeName;
     this.oidcClaimName = oidcClaimName;
-    this.idToken = idToken;
-    this.accessToken = accessToken;
-    this.userInfo = userInfo;
   }
 
   /**
@@ -63,27 +51,6 @@ public class AttributeClaim {
    */
   public String getOidcClaimName() {
     return this.oidcClaimName;
-  }
-
-  /**
-   * @return id token
-   */
-  public Boolean getIdToken() {
-    return this.idToken;
-  }
-
-  /**
-   * @return access token
-   */
-  public Boolean getAccessToken() {
-    return this.accessToken;
-  }
-
-  /**
-   * @return user info
-   */
-  public Boolean getUserInfo() {
-    return this.userInfo;
   }
 
   /**
@@ -107,9 +74,6 @@ public class AttributeClaim {
   public static class Builder {
     private final String samlAttributeName;
     private final String oidcClaimName;
-    private Boolean idToken = false;
-    private Boolean accessToken = false;
-    private Boolean userInfo = false;
 
     /**
      * Constructor.
@@ -122,42 +86,12 @@ public class AttributeClaim {
     }
 
     /**
-     * @param accessToken true if this claim should be present in access token
-     * @return this
-     */
-    public Builder accessToken(final Boolean accessToken) {
-      this.accessToken = accessToken;
-      return this;
-    }
-
-    /**
-     * @param userInfo true if this claim should be present in user info
-     * @return this
-     */
-    public Builder userInfo(final Boolean userInfo) {
-      this.userInfo = userInfo;
-      return this;
-    }
-
-    /**
-     * @param idToken true if this claim should be present in id token
-     * @return this
-     */
-    public Builder idToken(final Boolean idToken) {
-      this.idToken = idToken;
-      return this;
-    }
-
-    /**
      * @return new AttributeClaim instance
      */
     public AttributeClaim build() {
       return new AttributeClaim(
           this.samlAttributeName,
-          this.oidcClaimName,
-          this.idToken,
-          this.accessToken,
-          this.userInfo
+          this.oidcClaimName
       );
     }
   }

--- a/sweden-connect-provider/src/main/java/se/swedenconnect/keycloak/oidc/AttributeToClaim.java
+++ b/sweden-connect-provider/src/main/java/se/swedenconnect/keycloak/oidc/AttributeToClaim.java
@@ -29,21 +29,6 @@ public class AttributeToClaim {
 
   public static List<AttributeClaim> ATTRIBUTE_MAPPINGS = claimMappings();
 
-  public static Map<String, AttributeClaim> NON_DEFAULT_CLAIMS = Map.of(
-      "https://id.oidc.se/claim/userSignature", AttributeClaim.builder(
-              "urn:oid:1.2.752.201.3.11",
-              "https://id.oidc.se/claim/userSignature"
-          ).build(),
-      "https://id.oidc.se/claim/userCertificate", AttributeClaim.builder(
-              "urn:oid:1.2.752.201.3.10",
-              "https://id.oidc.se/claim/userCertificate"
-          ).build(),
-      "https://id.oidc.se/claim/authnEvidence", AttributeClaim.builder(
-              "urn:oid:1.2.752.201.3.13",
-              "https://id.oidc.se/claim/authnEvidence"
-          ).build()
-  );
-
   private static List<AttributeClaim> claimMappings() {
     final ArrayList<AttributeClaim> attributeClaims = new ArrayList<>();
 
@@ -106,6 +91,40 @@ public class AttributeToClaim {
         ).build()
     );
 
+    attributeClaims.add(
+        AttributeClaim.builder(
+            "urn:oid:1.2.752.201.3.11",
+            "https://id.oidc.se/claim/userSignature"
+        ).build()
+    );
+
+    attributeClaims.add(
+        AttributeClaim.builder(
+            "urn:oid:1.2.752.201.3.10",
+            "https://id.oidc.se/claim/userCertificate"
+        ).build()
+    );
+
+    attributeClaims.add(
+        AttributeClaim.builder(
+            "urn:oid:1.2.752.201.3.13",
+            "https://id.oidc.se/claim/authnEvidence"
+        ).build()
+    );
+
     return attributeClaims;
+  }
+
+  /**
+   * Convert config to list of attribute claims
+   * @param config to convert
+   * @return list of mappings
+   */
+  public static List<AttributeClaim> fromConfiguration(final Map<String, String> config) {
+    return config
+        .entrySet()
+        .stream()
+        .map(entry -> new AttributeClaim(entry.getKey(), entry.getValue())
+    ).toList();
   }
 }

--- a/sweden-connect-provider/src/main/java/se/swedenconnect/keycloak/oidc/ClaimsParameter.java
+++ b/sweden-connect-provider/src/main/java/se/swedenconnect/keycloak/oidc/ClaimsParameter.java
@@ -152,10 +152,8 @@ public class ClaimsParameter implements Predicate<AttributeClaim> {
 
   @Override
   public String toString() {
-    final StringBuffer sb = new StringBuffer("ClaimsParameter{");
-    sb.append("claims=").append(this.claims);
-    sb.append(", tokenType=").append(this.tokenType);
-    sb.append('}');
-    return sb.toString();
+    return "ClaimsParameter{" + "claims=" + this.claims +
+        ", tokenType=" + this.tokenType +
+        '}';
   }
 }

--- a/sweden-connect-provider/src/test/java/se/swedenconnect/test/MapperWrapper.java
+++ b/sweden-connect-provider/src/test/java/se/swedenconnect/test/MapperWrapper.java
@@ -17,6 +17,8 @@
 
 package se.swedenconnect.test;
 
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.KeycloakSession;
@@ -55,12 +57,19 @@ public class MapperWrapper {
     Mockito.when(mock.getUser()).thenReturn(userModel);
     final ProtocolMapperModel model = new ProtocolMapperModel();
     model.setConfig(Map.of("attribute.username.key", "urn:oid:1.2.752.29.4.13"));
+    final ClientSessionContext csc = Mockito.mock(ClientSessionContext.class);
+    final AuthenticatedClientSessionModel acsm = Mockito.mock(AuthenticatedClientSessionModel.class);
+    Mockito.when(csc.getScopeString(true)).thenReturn("oidc");
+    Mockito.when(csc.getClientSession()).thenReturn(acsm);
+    final ClientModel client = Mockito.mock(ClientModel.class);
+    Mockito.when(acsm.getClient()).thenReturn(client);
+    Mockito.when(client.getClientId()).thenReturn("testclient");
     final AccessToken accessToken = mapper.transformAccessToken(
         new AccessToken(),
         model,
         Mockito.mock(KeycloakSession.class),
         mock,
-        Mockito.mock(ClientSessionContext.class)
+        csc
     );
 
     final IDToken idToken = mapper.transformIDToken(
@@ -68,14 +77,14 @@ public class MapperWrapper {
         model,
         Mockito.mock(KeycloakSession.class),
         mock,
-        Mockito.mock(ClientSessionContext.class)
+        csc
     );
 
     final AccessToken userInfo = mapper.transformUserInfoToken(new AccessToken(),
         Mockito.mock(ProtocolMapperModel.class),
         Mockito.mock(KeycloakSession.class),
         mock,
-        Mockito.mock(ClientSessionContext.class));
+        csc);
 
     return new MappingTestResult(testContext.getSamlAttributes(), idToken, accessToken, userInfo);
   }


### PR DESCRIPTION
## Without configuration
```json
accessToken:
{
  "azp" : "https://client2.local.test",
  "scope" : "openid",
  "iss" : "https://auth.local.test/realms/test",
  "typ" : "Bearer",
  "exp" : 1746608432,
  "iat" : 1746608132,
  "jti" : "onrtac:079299be-a8cf-46c7-862e-8f7d8f2b1ffa",
  "client_id" : "https://client2.local.test",
  "sid" : "11998d66-dc99-4a59-985f-6378d4bdf19b"
}
```
## Apply configuration in Keycloak
![configure-mapping-saml-oidc](https://github.com/user-attachments/assets/8e0e1924-26e1-4281-8a2f-f59b73c6e835)
## After Configuration
```json
accessToken:
{
  "sub" : "197309069289",
  "azp" : "https://client2.local.test",
  "scope" : "openid",
  "iss" : "https://auth.local.test/realms/test",
  "typ" : "Bearer",
  "exp" : 1746608410,
  "iat" : 1746608110,
  "jti" : "onrtac:3abe706a-44b7-45bd-9b3f-1d3786029ecb",
  "client_id" : "https://client2.local.test",
  "sid" : "11998d66-dc99-4a59-985f-6378d4bdf19b"
}
```
