### PR TITLE
Add idp-hint-oidc-provider and saml-session-note-mapper plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This repository consists of a keycloak plugins to use in accordance to [Swedish 
 - [Sweden Connect Provider](docs/sweden-connect-provider.MD)
 - [Keycloak Login Customizer](docs/keycloak-login-customizer.MD)
 - [Tools](docs/tools.MD)
+- [IdP-Hint OIDC Provider](idp-hint-oidc-provider/README.md)
+- [SAML Session Note Mapper](saml-session-note-mapper/README.md)
 
 ## Contributing
 
@@ -29,4 +31,4 @@ The Keycloak Plugins is Open Source software released under the [Apache License]
 
 -----
 
-Copyright &copy; 2025, [Myndigheten för digital förvaltning - Swedish Agency for Digital Government (DIGG)](http://www.digg.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
+Copyright &copy; 2025-2026, [Myndigheten för digital förvaltning - Swedish Agency for Digital Government (DIGG)](http://www.digg.se). Licensed under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/idp-hint-oidc-provider/README.md
+++ b/idp-hint-oidc-provider/README.md
@@ -1,0 +1,66 @@
+![Sweden Connect](../docs/images/sweden-connect.png)
+
+# idp-hint-oidc-provider
+
+A Keycloak 26.x custom OIDC identity provider that forwards the `kc_idp_hint` query parameter
+from the broker button-click URL to the upstream realm's authorization request, enabling
+single-page IdP selection without an extra login-page redirect.
+
+## What it does
+
+In a two-realm brokering chain such as `orgiam → OIDC → Transient → SAML IdP`, users can be
+presented with IdP-selection buttons (BankID, RefIDP, etc.) on the orgiam login page. Clicking
+a button appends `kc_idp_hint=<alias>` to the broker URL, telling the Transient realm which
+SAML IdP to use — skipping the Transient realm's own login page entirely.
+
+Keycloak's built-in `forwardParameters` mechanism for OIDC identity providers reads
+`kc_idp_hint` from the auth-session note that was populated from the *original* client request,
+not from the broker redirect URL. This means the hint set by an IdP-selection button is
+silently discarded and never reaches the Transient realm.
+
+This provider overrides `createAuthorizationUrl()` to also inspect the **current HTTP request's
+query parameters** for `kc_idp_hint`, appending it to the upstream authorization URL when
+present. The result is that a button click on the orgiam login page reliably routes the user to
+the correct SAML IdP in the Transient realm with no extra redirects.
+
+**Provider ID:** `oidc-idp-hint`
+**Display name:** `OpenID Connect v1.0 (kc_idp_hint forwarding)`
+
+## Build
+
+```bash
+mvn -U -DskipTests clean package
+```
+
+(Run from the repository root or from `idp-hint-oidc-provider/`.)
+
+## Install into Keycloak 26.x
+
+```bash
+cp target/idp-hint-oidc-provider-<version>.jar /opt/keycloak/providers/
+/opt/keycloak/bin/kc.sh build
+/opt/keycloak/bin/kc.sh start --optimized
+```
+
+## Configure in the Admin Console
+
+Use this provider **instead of** the standard `OpenID Connect v1.0` provider when the upstream
+realm must receive `kc_idp_hint` from the broker URL.
+
+1. In the orgiam realm, go to **Identity Providers** → **Add provider** → select
+   **OpenID Connect v1.0 (kc_idp_hint forwarding)**.
+2. Configure it identically to a standard OIDC identity provider (discovery URL, client ID,
+   client secret / `private_key_jwt`, etc.).
+3. In the provider's **Advanced** settings, add `kc_idp_hint` to **Forwarded query parameters**
+   so Keycloak also forwards hints arriving from the initial client request (belt-and-suspenders
+   alongside the URL-parameter forwarding this provider adds).
+4. On the orgiam login page theme, add one button per upstream SAML IdP. Each button should
+   include `kc_idp_hint=<transient-realm-idp-alias>` in the broker redirect URL. The provider
+   will forward this to the Transient realm, which will skip its login page and go directly to
+   the named SAML IdP.
+
+---
+
+Copyright &copy; 2026, [Myndigheten för digital förvaltning - Swedish Agency for
+Digital Government (DIGG)](https://www.digg.se). Licensed under version 2.0 of the
+[Apache License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/idp-hint-oidc-provider/pom.xml
+++ b/idp-hint-oidc-provider/pom.xml
@@ -1,0 +1,92 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>se.swedenconnect.keycloak</groupId>
+    <artifactId>keycloak-plugins-parent</artifactId>
+    <version>0.4.9</version>
+  </parent>
+
+  <artifactId>idp-hint-oidc-provider</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Sweden Connect :: Keycloak :: IdP-Hint OIDC Provider</name>
+  <description>Custom OIDC identity provider that forwards kc_idp_hint from the broker button
+    click URL to the upstream realm's authorization request, enabling single-page IdP selection
+    across a two-realm brokering chain.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-server-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-server-spi-private</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.23.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.23.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Provides jakarta.ws.rs.ext.RuntimeDelegate needed by OIDCIdentityProvider.<clinit> -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-core</artifactId>
+      <version>6.2.12.Final</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Implementation-Title>${project.artifactId}</Implementation-Title>
+              <Implementation-Version>${project.version}</Implementation-Version>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/idp-hint-oidc-provider/src/main/java/se/swedenconnect/keycloak/broker/IdpHintOidcIdentityProvider.java
+++ b/idp-hint-oidc-provider/src/main/java/se/swedenconnect/keycloak/broker/IdpHintOidcIdentityProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.broker;
+
+import jakarta.ws.rs.core.UriBuilder;
+import org.jboss.logging.Logger;
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.provider.AuthenticationRequest;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * OIDC identity provider that forwards {@code kc_idp_hint} from the broker button-click URL to the
+ * upstream realm's authorization request.
+ *
+ * <p>Keycloak's built-in {@code forwardParameters} mechanism reads {@code kc_idp_hint} from the
+ * authentication-session notes, which are populated from the <em>initial</em> client authorization
+ * request. In a two-realm brokering chain (orgiam → Transient → SAML IdP) the initial request from
+ * the application does not carry {@code kc_idp_hint}; instead the hint is appended to the broker
+ * login URL by the custom {@code login.ftl} when the user clicks an IdP button. This provider
+ * complements the session-note path by also reading {@code kc_idp_hint} directly from the current
+ * HTTP request query parameters, so the hint reaches the Transient realm's authorization endpoint.</p>
+ *
+ * @author David Goldring
+ */
+public class IdpHintOidcIdentityProvider extends OIDCIdentityProvider {
+
+  private static final Logger log = Logger.getLogger(IdpHintOidcIdentityProvider.class);
+
+  /** The query parameter name this provider forwards. */
+  public static final String KC_IDP_HINT = "kc_idp_hint";
+
+  /**
+   * Creates a new provider instance.
+   *
+   * @param session the Keycloak session
+   * @param config the OIDC identity provider configuration
+   */
+  public IdpHintOidcIdentityProvider(
+      final KeycloakSession session, final OIDCIdentityProviderConfig config) {
+    super(session, config);
+  }
+
+  /**
+   * Builds the upstream authorization URL, adding {@code kc_idp_hint} from the current HTTP
+   * request when present.
+   *
+   * @param request the authentication request context
+   * @return the authorization URL builder, with {@code kc_idp_hint} appended if supplied
+   */
+  @Override
+  protected UriBuilder createAuthorizationUrl(final AuthenticationRequest request) {
+    final UriBuilder uriBuilder = super.createAuthorizationUrl(request);
+    return this.appendIdpHintParam(uriBuilder, request);
+  }
+
+  /**
+   * Appends {@code kc_idp_hint} to the upstream authorization URL when the current HTTP request
+   * carries the parameter.
+   *
+   * <p>Extracted as a {@code protected} method to allow unit testing without depending on the
+   * full {@link org.keycloak.broker.oidc.OIDCIdentityProvider} base-class constructor chain.</p>
+   *
+   * @param uriBuilder the base authorization URL builder returned by the super implementation
+   * @param request the current authentication request
+   * @return the same builder, with {@code kc_idp_hint} appended when present and non-blank
+   */
+  protected UriBuilder appendIdpHintParam(
+      final UriBuilder uriBuilder, final AuthenticationRequest request) {
+    final String hint = request.getHttpRequest().getUri()
+        .getQueryParameters().getFirst(KC_IDP_HINT);
+    if (hint != null && !hint.isBlank()) {
+      log.debugf("Forwarding %s=%s to upstream IdP %s", KC_IDP_HINT, hint, this.getConfig().getAlias());
+      uriBuilder.queryParam(KC_IDP_HINT, hint);
+    }
+    return uriBuilder;
+  }
+}

--- a/idp-hint-oidc-provider/src/main/java/se/swedenconnect/keycloak/broker/IdpHintOidcIdentityProviderFactory.java
+++ b/idp-hint-oidc-provider/src/main/java/se/swedenconnect/keycloak/broker/IdpHintOidcIdentityProviderFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.broker;
+
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * Factory for {@link IdpHintOidcIdentityProvider}.
+ *
+ * <p>Registers the {@value #PROVIDER_ID} identity provider type in Keycloak's SPI registry.
+ * Configure this type on any OIDC IdP where {@code kc_idp_hint} must be forwarded from the
+ * broker button-click URL to the upstream realm's authorization request.</p>
+ *
+ * @author David Goldring
+ */
+public class IdpHintOidcIdentityProviderFactory extends OIDCIdentityProviderFactory {
+
+  /** The provider type identifier used in Keycloak's admin UI and REST API. */
+  public static final String PROVIDER_ID = "oidc-idp-hint";
+
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
+
+  @Override
+  public String getName() {
+    return "OpenID Connect v1.0 (kc_idp_hint forwarding)";
+  }
+
+  @Override
+  public String getHelpText() {
+    return "OIDC identity provider that also forwards kc_idp_hint from the broker login URL "
+        + "to the upstream authorization request. Use this instead of the standard OIDC type "
+        + "when the upstream realm must receive kc_idp_hint to skip its own login page.";
+  }
+
+  @Override
+  public IdpHintOidcIdentityProvider create(
+      final KeycloakSession session, final IdentityProviderModel model) {
+    return new IdpHintOidcIdentityProvider(session, new OIDCIdentityProviderConfig(model));
+  }
+}

--- a/idp-hint-oidc-provider/src/main/java/se/swedenconnect/keycloak/broker/package-info.java
+++ b/idp-hint-oidc-provider/src/main/java/se/swedenconnect/keycloak/broker/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+/**
+ * Custom OIDC identity provider that forwards {@code kc_idp_hint} to upstream realms.
+ *
+ * @author David Goldring
+ */
+package se.swedenconnect.keycloak.broker;

--- a/idp-hint-oidc-provider/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderFactory
+++ b/idp-hint-oidc-provider/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderFactory
@@ -1,0 +1,1 @@
+se.swedenconnect.keycloak.broker.IdpHintOidcIdentityProviderFactory

--- a/idp-hint-oidc-provider/src/test/java/se/swedenconnect/keycloak/broker/IdpHintOidcIdentityProviderFactoryTest.java
+++ b/idp-hint-oidc-provider/src/test/java/se/swedenconnect/keycloak/broker/IdpHintOidcIdentityProviderFactoryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.broker;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Unit tests for {@link IdpHintOidcIdentityProviderFactory}.
+ *
+ * @author David Goldring
+ */
+@ExtendWith(MockitoExtension.class)
+class IdpHintOidcIdentityProviderFactoryTest {
+
+  @Mock
+  private KeycloakSession session;
+
+  private final IdpHintOidcIdentityProviderFactory factory = new IdpHintOidcIdentityProviderFactory();
+
+  @Test
+  void getId_returnsProviderId() {
+    assertEquals(IdpHintOidcIdentityProviderFactory.PROVIDER_ID, this.factory.getId());
+  }
+
+  @Test
+  void getName_isNonBlank() {
+    assertNotNull(this.factory.getName());
+    org.junit.jupiter.api.Assertions.assertFalse(this.factory.getName().isBlank());
+  }
+
+  @Test
+  void getHelpText_isNonBlank() {
+    assertNotNull(this.factory.getHelpText());
+    org.junit.jupiter.api.Assertions.assertFalse(this.factory.getHelpText().isBlank());
+  }
+
+  @Test
+  void create_returnsIdpHintOidcIdentityProvider() {
+    final IdentityProviderModel model = new IdentityProviderModel();
+    model.setAlias("test-idp");
+
+    final IdpHintOidcIdentityProvider provider = this.factory.create(this.session, model);
+
+    assertInstanceOf(IdpHintOidcIdentityProvider.class, provider);
+  }
+}

--- a/idp-hint-oidc-provider/src/test/java/se/swedenconnect/keycloak/broker/IdpHintOidcIdentityProviderTest.java
+++ b/idp-hint-oidc-provider/src/test/java/se/swedenconnect/keycloak/broker/IdpHintOidcIdentityProviderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.broker;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.provider.AuthenticationRequest;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link IdpHintOidcIdentityProvider}.
+ *
+ * @author David Goldring
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class IdpHintOidcIdentityProviderTest {
+
+  @Mock
+  private KeycloakSession session;
+
+  @Mock
+  private AuthenticationRequest request;
+
+  @Mock
+  private HttpRequest httpRequest;
+
+  @Mock
+  private UriInfo uriInfo;
+
+  @Mock
+  private MultivaluedMap<String, String> queryParams;
+
+  @Mock
+  private UriBuilder uriBuilder;
+
+  private IdpHintOidcIdentityProvider provider;
+
+  @BeforeEach
+  void setUp() {
+    final IdentityProviderModel model = new IdentityProviderModel();
+    model.setAlias("transient-realm");
+    final OIDCIdentityProviderConfig config = new OIDCIdentityProviderConfig(model);
+    this.provider = spy(new IdpHintOidcIdentityProvider(this.session, config));
+
+    when(this.request.getHttpRequest()).thenReturn(this.httpRequest);
+    when(this.httpRequest.getUri()).thenReturn(this.uriInfo);
+    when(this.uriInfo.getQueryParameters()).thenReturn(this.queryParams);
+  }
+
+  @Test
+  void hintPresent_appendedToUriBuilder() {
+    when(this.queryParams.getFirst(IdpHintOidcIdentityProvider.KC_IDP_HINT)).thenReturn("bankid");
+
+    this.provider.appendIdpHintParam(this.uriBuilder, this.request);
+
+    verify(this.uriBuilder).queryParam(IdpHintOidcIdentityProvider.KC_IDP_HINT, "bankid");
+  }
+
+  @Test
+  void hintAbsent_uriBuilderUnchanged() {
+    when(this.queryParams.getFirst(IdpHintOidcIdentityProvider.KC_IDP_HINT)).thenReturn(null);
+
+    this.provider.appendIdpHintParam(this.uriBuilder, this.request);
+
+    verify(this.uriBuilder, never()).queryParam(any(), any());
+  }
+
+  @Test
+  void hintBlank_uriBuilderUnchanged() {
+    when(this.queryParams.getFirst(IdpHintOidcIdentityProvider.KC_IDP_HINT)).thenReturn("   ");
+
+    this.provider.appendIdpHintParam(this.uriBuilder, this.request);
+
+    verify(this.uriBuilder, never()).queryParam(any(), any());
+  }
+
+  @Test
+  void hintEmpty_uriBuilderUnchanged() {
+    when(this.queryParams.getFirst(IdpHintOidcIdentityProvider.KC_IDP_HINT)).thenReturn("");
+
+    this.provider.appendIdpHintParam(this.uriBuilder, this.request);
+
+    verify(this.uriBuilder, never()).queryParam(any(), any());
+  }
+
+  @Test
+  void appendIdpHintParam_returnsUriBuilder() {
+    when(this.queryParams.getFirst(IdpHintOidcIdentityProvider.KC_IDP_HINT)).thenReturn("siths");
+
+    final UriBuilder result = this.provider.appendIdpHintParam(this.uriBuilder, this.request);
+
+    org.junit.jupiter.api.Assertions.assertSame(this.uriBuilder, result);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
         <module>keycloak-login-customizer</module>
         <module>pkcs11</module>
         <module>oidf</module>
+        <module>idp-hint-oidc-provider</module>
+        <module>saml-session-note-mapper</module>
     </modules>
 
     <properties>
@@ -100,7 +102,7 @@
                     <checkstyleRules>
                         <module name="Checker">
                             <module name="RegexpHeader">
-                                <property name="header" value="/*\n * Copyright (2024-)?2025 Sweden Connect"/>
+                                <property name="header" value="/*\n * Copyright (202[45]-)?202[56] Sweden Connect"/>
                             </module>
                             <module name="LineLength">
                                 <property name="max" value="120"/>

--- a/saml-session-note-mapper/README.md
+++ b/saml-session-note-mapper/README.md
@@ -1,0 +1,139 @@
+![Sweden Connect](../docs/images/sweden-connect.png)
+
+# saml-session-note-mapper
+
+Keycloak SPI module providing three identity provider mappers that together propagate a stable
+Swedish personal identity number (personnummer) through a two-realm brokering chain:
+
+```
+orgiam realm  →  OIDC  →  Transient realm  →  SAML  →  eIDAS / BankID / RefIDP
+```
+
+## Background
+
+The Transient realm is configured with `doNotStoreUsers=true`, which means every session creates
+an in-memory `LightweightUserAdapter` whose `sub` claim is a fresh `lightweight-<UUID>` per
+session. Keycloak's built-in `OIDCIdentityProvider.extractIdentity()` always uses `sub` as the
+broker identity ID regardless of any `principalType=ATTRIBUTE` configuration. This causes a
+`ModelDuplicateException` on second logins and prevents stable account linking.
+
+The three mappers in this module solve this by extracting the personnummer from the SAML assertion
+and propagating it through the token chain so that orgiam uses it as the stable
+`identity_provider_identity`.
+
+## Mapper pipeline
+
+### 1. `SamlSessionNoteMapper` — Transient realm, SAML IdP mapper
+
+Reads a SAML attribute from the assertion (configured by name or friendly name) and stores its
+value as both a user session note and a user model attribute.
+
+**Why two storage paths?** With `doNotStoreUsers=true`, auth-session user-session notes are not
+reliably transferred to the `UserSessionModel` note map. The user model attribute is a fallback
+that survives via the `keycloak.userModel` session note.
+
+**Configuration:**
+
+| Property | Default | Description |
+|---|---|---|
+| Attribute Name | — | SAML attribute name (e.g. `urn:oid:1.2.752.29.4.13`) |
+| Friendly Name | — | SAML attribute friendly name (e.g. `personalIdentityNumber`) |
+| User Session Note | `transient_personal_identity_number` | Key under which to store the value |
+
+Deploy on: **Transient realm → Identity Providers → `<SAML IdP>` → Mappers**
+
+---
+
+### 2. `SessionNoteClaimMapper` — Transient realm, OIDC protocol mapper
+
+Reads the session note written by `SamlSessionNoteMapper` and emits it as an OIDC claim in the
+id-token, access token, and UserInfo response. Falls back to reading from the user model attribute
+if the session note is absent.
+
+**Why a dot-free claim name?** Keycloak's `OIDCAttributeMapperHelper` splits claim names on
+unescaped dots, turning `personal.identity.number` into a nested JSON object. Using a dot-free
+name such as `personalIdentityNumber` avoids this.
+
+**Configuration:**
+
+| Property | Default | Description |
+|---|---|---|
+| User Session Note | `transient_personal_identity_number` | Session note key to read from |
+| Token Claim Name | `personalIdentityNumber` | Claim name to emit in the token |
+
+Deploy on: **Transient realm → Clients → `<orgiam OIDC client>` → Client scopes → Mappers**
+
+---
+
+### 3. `OidcClaimToBrokerIdMapper` — orgiam realm, OIDC IdP mapper
+
+Reads the personnummer claim from the validated id-token received from the Transient realm and
+calls both `context.setId(pnr)` and `context.setUsername(pnr)` on the `BrokeredIdentityContext`
+before `FederatedIdentityModel` is created.
+
+- `setId(pnr)` ensures `identity_provider_identity` in `FEDERATED_IDENTITY` is the stable
+  personnummer rather than the ephemeral `lightweight-<UUID>`.
+- `setUsername(pnr)` enables the `Detect existing broker user` First Broker Login authenticator
+  to find a pre-provisioned orgiam user by username (requires `pnr-userids: true` in
+  iam-admin-app configuration).
+
+**Configuration:**
+
+| Property | Default | Description |
+|---|---|---|
+| Claim Name | `personalIdentityNumber` | Claim to read from the id-token |
+
+Deploy on: **orgiam realm → Identity Providers → `orgiam.realm` → Mappers**
+
+---
+
+## First Broker Login flow
+
+The orgiam realm must use a custom First Broker Login flow for the `orgiam.realm` OIDC IdP.
+The recommended flow ("AutoLinkIdpUser") contains:
+
+| Step | Authenticator | Requirement |
+|---|---|---|
+| Detect existing broker user | `idp-detect-existing-broker-user` | Required |
+| Automatically set existing user | `idp-auto-link` | Required |
+
+**Detect existing broker user** finds the pre-provisioned orgiam user by username=personnummer
+(set by `OidcClaimToBrokerIdMapper`) and stores the match in the auth session. If no matching
+orgiam user is found, login is denied — unknown users are never auto-created.
+
+**Automatically set existing user** reads the match stored by the previous step and completes
+the login without requiring email verification or re-authentication, which is appropriate since
+the user has already been authenticated by a Swedish eID.
+
+`Create User If Unique` must **not** be present in this flow, as it would create orgiam accounts
+for users who have not been provisioned by iam-admin-app.
+
+---
+
+## Build
+
+```bash
+mvn -U -DskipTests clean package
+```
+
+(Run from the repository root or from `saml-session-note-mapper/`.)
+
+## Install into Keycloak 26.x
+
+```bash
+cp target/saml-session-note-mapper-<version>.jar /opt/keycloak/providers/
+/opt/keycloak/bin/kc.sh build
+/opt/keycloak/bin/kc.sh start --optimized
+```
+
+## Running tests
+
+```bash
+mvn test -pl saml-session-note-mapper
+```
+
+---
+
+Copyright &copy; 2026, [Myndigheten för digital förvaltning - Swedish Agency for
+Digital Government (DIGG)](https://www.digg.se). Licensed under version 2.0 of the
+[Apache License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/saml-session-note-mapper/pom.xml
+++ b/saml-session-note-mapper/pom.xml
@@ -1,0 +1,93 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>se.swedenconnect.keycloak</groupId>
+    <artifactId>keycloak-plugins-parent</artifactId>
+    <version>0.4.9</version>
+  </parent>
+
+  <artifactId>saml-session-note-mapper</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Sweden Connect :: Keycloak :: SAML Session Note Mapper</name>
+  <description>
+    Keycloak SPI plugin pair: SamlSessionNoteMapper reads a SAML assertion attribute and stores
+    it as a user session note; SessionNoteClaimMapper emits the note as an OIDC token claim.
+    Designed for transient proxy realms (doNotStoreUsers=true) to propagate identity attributes
+    into downstream tokens without persisting personal data.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-server-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-server-spi-private</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-saml-core-public</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.23.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.23.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Implementation-Title>${project.artifactId}</Implementation-Title>
+              <Implementation-Version>${project.version}</Implementation-Version>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/saml-session-note-mapper/src/main/java/se/swedenconnect/keycloak/transientidp/OidcClaimToBrokerIdMapper.java
+++ b/saml-session-note-mapper/src/main/java/se/swedenconnect/keycloak/transientidp/OidcClaimToBrokerIdMapper.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.transientidp;
+
+import org.jboss.logging.Logger;
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.provider.AbstractIdentityProviderMapper;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.JsonWebToken;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * An OIDC identity provider mapper that reads a claim from the validated id-token and overrides
+ * the brokered identity's ID ({@code identity_provider_identity}) with its value.
+ *
+ * <p>Keycloak's built-in {@code OIDCIdentityProvider.extractIdentity} always uses the {@code sub}
+ * claim as the broker identity ID, regardless of any {@code principalType=ATTRIBUTE} /
+ * {@code principalAttribute} configuration. For a transient proxy realm (doNotStoreUsers=true),
+ * the {@code sub} is a fresh {@code lightweight-&lt;UUID&gt;} per session, causing
+ * {@code ModelDuplicateException} on second logins.</p>
+ *
+ * <p>This mapper runs <em>after</em> {@code extractIdentity} has populated the
+ * {@link BrokeredIdentityContext} and calls both {@link BrokeredIdentityContext#setId(String)} and
+ * {@link BrokeredIdentityContext#setUsername(String)} with the configured claim value, replacing
+ * the ephemeral {@code sub} / {@code lightweight-&lt;UUID&gt;} username with a stable identifier
+ * such as a Swedish personal identity number.</p>
+ *
+ * <p>Setting the username to the same stable value is required for the Keycloak
+ * "Automatically set existing user" First Broker Login authenticator to locate a pre-provisioned
+ * orgiam user by personal identity number (when {@code pnr-userids=true} is configured in
+ * iam-admin-app) and link the federated identity to it, without creating a duplicate account.</p>
+ *
+ * <p>Configure this mapper on the orgiam OIDC identity provider that connects to the Transient
+ * realm, with {@code claim.name = personalIdentityNumber} (the dot-free claim emitted by
+ * {@link SessionNoteClaimMapper}).</p>
+ *
+ * @author David Goldring
+ */
+public class OidcClaimToBrokerIdMapper extends AbstractIdentityProviderMapper {
+
+  private static final Logger LOG = Logger.getLogger(OidcClaimToBrokerIdMapper.class);
+
+  /** Provider ID used to reference this mapper in Keycloak configuration. */
+  public static final String PROVIDER_ID = "oidc-claim-to-broker-id-mapper";
+
+  /** Configuration key for the claim name to read from the id-token. */
+  public static final String CLAIM_NAME_CONFIG = "claim.name";
+
+  /** Default claim name — matches {@link SessionNoteClaimMapper#DEFAULT_CLAIM_NAME}. */
+  public static final String DEFAULT_CLAIM_NAME = SessionNoteClaimMapper.DEFAULT_CLAIM_NAME;
+
+  private static final String[] COMPATIBLE_PROVIDERS = { "oidc", "keycloak-oidc" };
+
+  private static final Set<IdentityProviderSyncMode> SYNC_MODES =
+      new HashSet<>(Arrays.asList(IdentityProviderSyncMode.values()));
+
+  private static final List<ProviderConfigProperty> CONFIG_PROPERTIES;
+
+  static {
+    final List<ProviderConfigProperty> props = new ArrayList<>();
+
+    final ProviderConfigProperty claimProp = new ProviderConfigProperty();
+    claimProp.setName(CLAIM_NAME_CONFIG);
+    claimProp.setLabel("Claim Name");
+    claimProp.setHelpText(
+        "Name of the claim in the validated id-token to use as the broker identity ID "
+            + "(identity_provider_identity). Must match the claim emitted by the "
+            + "\"Session Note to Claim\" protocol mapper on the OIDC client in the transient "
+            + "realm. Use a dot-free name (e.g. personalIdentityNumber) to avoid Keycloak's "
+            + "claim-path splitting.");
+    claimProp.setType(ProviderConfigProperty.STRING_TYPE);
+    claimProp.setDefaultValue(DEFAULT_CLAIM_NAME);
+    props.add(claimProp);
+
+    CONFIG_PROPERTIES = Collections.unmodifiableList(props);
+  }
+
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
+
+  @Override
+  public String[] getCompatibleProviders() {
+    return COMPATIBLE_PROVIDERS;
+  }
+
+  @Override
+  public boolean supportsSyncMode(final IdentityProviderSyncMode syncMode) {
+    return SYNC_MODES.contains(syncMode);
+  }
+
+  @Override
+  public String getDisplayType() {
+    return "OIDC Claim to Broker Identity ID";
+  }
+
+  @Override
+  public String getDisplayCategory() {
+    return "Broker Identity Override";
+  }
+
+  @Override
+  public String getHelpText() {
+    return "Reads a claim from the validated id-token and overrides the brokered identity's "
+        + "identity_provider_identity with its value. Use this on an OIDC identity provider "
+        + "that fronts a transient (doNotStoreUsers=true) realm to replace the ephemeral "
+        + "lightweight-<UUID> sub with a stable identifier such as a personal identity number. "
+        + "Pair with the \"Session Note to Claim\" OIDC protocol mapper in the transient realm "
+        + "that emits the identity as a dot-free claim (e.g. personalIdentityNumber).";
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return CONFIG_PROPERTIES;
+  }
+
+  /**
+   * Reads the configured claim from the validated id-token and calls
+   * {@link BrokeredIdentityContext#setId(String)} to replace the ephemeral {@code sub}.
+   */
+  @Override
+  public void preprocessFederatedIdentity(
+      final KeycloakSession session,
+      final RealmModel realm,
+      final IdentityProviderMapperModel mapperModel,
+      final BrokeredIdentityContext context) {
+
+    final String claimName = resolveClaimName(mapperModel);
+    final String value = this.readClaimFromIdToken(context, claimName);
+
+    if (value == null || value.isBlank()) {
+      LOG.warnf("Claim '%s' absent in id-token from IdP '%s' — broker identity ID not overridden; "
+              + "second logins will likely fail with ModelDuplicateException",
+          claimName, context.getIdpConfig().getAlias());
+      return;
+    }
+
+    LOG.debugf("Overriding broker identity ID and username with claim '%s'='%s' for IdP '%s'",
+        claimName, value, context.getIdpConfig().getAlias());
+    context.setId(value);
+    context.setUsername(value);
+  }
+
+  /**
+   * Also, override on update so subsequent logins resolve correctly.
+   */
+  @Override
+  public void updateBrokeredUser(
+      final KeycloakSession session,
+      final RealmModel realm,
+      final UserModel user,
+      final IdentityProviderMapperModel mapperModel,
+      final BrokeredIdentityContext context) {
+    this.preprocessFederatedIdentity(session, realm, mapperModel, context);
+  }
+
+  /**
+   * Reads the claim value from the validated id-token stored in the brokered identity context.
+   */
+  private String readClaimFromIdToken(
+      final BrokeredIdentityContext context,
+      final String claimName) {
+    final Object tokenObj = context.getContextData().get(OIDCIdentityProvider.VALIDATED_ID_TOKEN);
+    if (tokenObj instanceof JsonWebToken idToken) {
+      final Object claim = idToken.getOtherClaims().get(claimName);
+      if (claim != null) {
+        return claim.toString();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Resolves the effective claim name from the mapper config, falling back to
+   * {@link #DEFAULT_CLAIM_NAME} when absent or blank.
+   *
+   * @param mapperModel the mapper configuration model
+   * @return the claim name to use
+   */
+  static String resolveClaimName(final IdentityProviderMapperModel mapperModel) {
+    final String name = mapperModel.getConfig().get(CLAIM_NAME_CONFIG);
+    return (name != null && !name.isBlank()) ? name : DEFAULT_CLAIM_NAME;
+  }
+
+}

--- a/saml-session-note-mapper/src/main/java/se/swedenconnect/keycloak/transientidp/SamlSessionNoteMapper.java
+++ b/saml-session-note-mapper/src/main/java/se/swedenconnect/keycloak/transientidp/SamlSessionNoteMapper.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.transientidp;
+
+import org.jboss.logging.Logger;
+import org.keycloak.broker.provider.AbstractIdentityProviderMapper;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.broker.saml.SAMLEndpoint;
+import org.keycloak.broker.saml.SAMLIdentityProviderFactory;
+import org.keycloak.dom.saml.v2.assertion.AssertionType;
+import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A SAML identity provider mapper that reads a configurable SAML assertion attribute and stores
+ * its value as a user session note on the authentication session.
+ *
+ * <p>The note is transferred to the {@code UserSessionModel} after successful authentication and
+ * is then available to OIDC protocol mappers — such as {@link SessionNoteClaimMapper} or the
+ * built-in <em>User Session Note</em> mapper — during token generation.</p>
+ *
+ * <p>This mapper is designed for transient proxy realms where {@code doNotStoreUsers=true}
+ * prevents user-model attributes from surviving beyond the current request. Because user session
+ * notes live in the session rather than on the user model, the attribute value is correctly
+ * propagated through the authorization code exchange even for lightweight (in-memory) users.</p>
+ *
+ * <p>Typical setup for Sweden Connect identity numbers:</p>
+ * <ul>
+ *   <li>Add one mapper instance per SAML IdP (BankID, RefIDP, eIDAS …) in the transient realm
+ *       with {@code attribute.name = urn:oid:1.2.752.29.4.13} and
+ *       {@code session.note = transient_personal_identity_number}.</li>
+ *   <li>Optionally add a second instance for coordination numbers
+ *       ({@code attribute.name = urn:oid:1.2.752.201.3.4}) writing to the same note key; the
+ *       second instance is a no-op when the assertion only contains a personnummer.</li>
+ *   <li>On the downstream OIDC client in the transient realm, add {@link SessionNoteClaimMapper}
+ *       (or the built-in <em>User Session Note</em> mapper) to emit the note as a token claim.</li>
+ * </ul>
+ *
+ * @author David Goldring
+ */
+public class SamlSessionNoteMapper extends AbstractIdentityProviderMapper {
+
+  private static final Logger LOG = Logger.getLogger(SamlSessionNoteMapper.class);
+
+  /** Provider ID used to reference this mapper in Keycloak configuration. */
+  public static final String PROVIDER_ID = "saml-session-note-mapper";
+
+  /** Configuration key for the SAML attribute name to read from the assertion. */
+  public static final String SAML_ATTRIBUTE_NAME = "attribute.name";
+
+  /** Configuration key for the SAML attribute friendly name (alternative to {@link #SAML_ATTRIBUTE_NAME}). */
+  public static final String SAML_ATTRIBUTE_FRIENDLY_NAME = "attribute.friendly.name";
+
+  /** Configuration key for the user session note name. */
+  public static final String SESSION_NOTE_CONFIG = "session.note";
+
+  /**
+   * Default user session note key written by this mapper. Used by {@link SessionNoteClaimMapper}
+   * as its default read key.
+   */
+  public static final String DEFAULT_SESSION_NOTE = "transient_personal_identity_number";
+
+  private static final String[] COMPATIBLE_PROVIDERS = { SAMLIdentityProviderFactory.PROVIDER_ID };
+
+  private static final Set<IdentityProviderSyncMode> SYNC_MODES =
+      new HashSet<>(Arrays.asList(IdentityProviderSyncMode.values()));
+
+  private static final List<ProviderConfigProperty> CONFIG_PROPERTIES;
+
+  static {
+    final List<ProviderConfigProperty> props = new ArrayList<>();
+
+    final ProviderConfigProperty attrNameProp = new ProviderConfigProperty();
+    attrNameProp.setName(SAML_ATTRIBUTE_NAME);
+    attrNameProp.setLabel("Attribute Name");
+    attrNameProp.setHelpText(
+        "Name of the SAML assertion attribute to read (e.g. urn:oid:1.2.752.29.4.13 for "
+            + "Swedish personnummer). Leave blank and use Friendly Name instead if preferred.");
+    attrNameProp.setType(ProviderConfigProperty.STRING_TYPE);
+    props.add(attrNameProp);
+
+    final ProviderConfigProperty attrFriendlyProp = new ProviderConfigProperty();
+    attrFriendlyProp.setName(SAML_ATTRIBUTE_FRIENDLY_NAME);
+    attrFriendlyProp.setLabel("Friendly Name");
+    attrFriendlyProp.setHelpText(
+        "Friendly name of the SAML attribute (alternative to Attribute Name). "
+            + "Attribute Name takes precedence when both are configured.");
+    attrFriendlyProp.setType(ProviderConfigProperty.STRING_TYPE);
+    props.add(attrFriendlyProp);
+
+    final ProviderConfigProperty sessionNoteProp = new ProviderConfigProperty();
+    sessionNoteProp.setName(SESSION_NOTE_CONFIG);
+    sessionNoteProp.setLabel("User Session Note");
+    sessionNoteProp.setHelpText(
+        "Name of the user session note to which the SAML attribute value is written. "
+            + "The note is transferred from the authentication session to the UserSessionModel "
+            + "after login and can be read by OIDC protocol mappers during token generation. "
+            + "When using multiple mapper instances (e.g. personnummer + coordination number), "
+            + "configure both with the same note key.");
+    sessionNoteProp.setType(ProviderConfigProperty.STRING_TYPE);
+    sessionNoteProp.setDefaultValue(DEFAULT_SESSION_NOTE);
+    props.add(sessionNoteProp);
+
+    CONFIG_PROPERTIES = Collections.unmodifiableList(props);
+  }
+
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
+
+  @Override
+  public String[] getCompatibleProviders() {
+    return COMPATIBLE_PROVIDERS;
+  }
+
+  @Override
+  public boolean supportsSyncMode(final IdentityProviderSyncMode syncMode) {
+    return SYNC_MODES.contains(syncMode);
+  }
+
+  @Override
+  public String getDisplayType() {
+    return "SAML Attribute to Session Note";
+  }
+
+  @Override
+  public String getDisplayCategory() {
+    return "Session Note Mapper";
+  }
+
+  @Override
+  public String getHelpText() {
+    return "Reads a configurable SAML assertion attribute and writes its value to a user session "
+        + "note. Designed for transient proxy realms (doNotStoreUsers=true) where user-model "
+        + "attributes do not survive beyond the current request. Pair with the "
+        + "\"Session Note to Claim\" OIDC protocol mapper (or the built-in "
+        + "\"User Session Note\" mapper) on the downstream client to emit the value as a token claim.";
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return CONFIG_PROPERTIES;
+  }
+
+  /**
+   * Reads the configured SAML attribute from the assertion and stores it as a user session note.
+   * If the attribute is absent or blank, the method returns without writing any note.
+   */
+  @Override
+  public void preprocessFederatedIdentity(
+      final KeycloakSession session,
+      final RealmModel realm,
+      final IdentityProviderMapperModel mapperModel,
+      final BrokeredIdentityContext context) {
+
+    final String value = this.readAttribute(context, mapperModel);
+    if (value == null || value.isBlank()) {
+      LOG.debugf("SAML attribute '%s' not present in assertion for IdP '%s' — skipping session note",
+          mapperModel.getConfig().get(SAML_ATTRIBUTE_NAME),
+          context.getIdpConfig().getAlias());
+      return;
+    }
+
+    final String noteKey = resolveNoteKey(mapperModel);
+    context.getAuthenticationSession().setUserSessionNote(noteKey, value);
+    LOG.debugf("Stored SAML attribute '%s' as user session note '%s' for IdP '%s'",
+        mapperModel.getConfig().get(SAML_ATTRIBUTE_NAME), noteKey,
+        context.getIdpConfig().getAlias());
+  }
+
+  /**
+   * Also sets the attribute value as a user model attribute under the same key as the session note.
+   *
+   * <p>This is a belt-and-suspenders complement to {@link #preprocessFederatedIdentity}. In some
+   * Keycloak deployments (specifically when {@code doNotStoreUsers=true} creates
+   * {@code LightweightUserAdapter} instances) user-session-notes set on the
+   * {@code AuthenticationSessionModel} are not transferred to the {@code UserSessionModel}'s
+   * note map. The lightweight user's attributes are, however, reliably serialised into the
+   * {@code keycloak.userModel} user-session note and remain accessible via
+   * {@code userSession.getUser().getFirstAttribute(key)} during token generation.</p>
+   */
+  @Override
+  public void importNewUser(
+      final KeycloakSession session,
+      final RealmModel realm,
+      final UserModel user,
+      final IdentityProviderMapperModel mapperModel,
+      final BrokeredIdentityContext context) {
+    this.setUserAttribute(user, mapperModel, context);
+  }
+
+  /**
+   * Also sets the attribute value as a user model attribute under the same key as the session note.
+   *
+   * @see #importNewUser
+   */
+  @Override
+  public void updateBrokeredUser(
+      final KeycloakSession session,
+      final RealmModel realm,
+      final UserModel user,
+      final IdentityProviderMapperModel mapperModel,
+      final BrokeredIdentityContext context) {
+    this.setUserAttribute(user, mapperModel, context);
+  }
+
+  private void setUserAttribute(
+      final UserModel user,
+      final IdentityProviderMapperModel mapperModel,
+      final BrokeredIdentityContext context) {
+    final String value = this.readAttribute(context, mapperModel);
+    if (value == null || value.isBlank()) {
+      return;
+    }
+    final String noteKey = resolveNoteKey(mapperModel);
+    user.setSingleAttribute(noteKey, value);
+    LOG.debugf("Set user attribute '%s' on lightweight user for IdP '%s'",
+        noteKey, context.getIdpConfig().getAlias());
+  }
+
+  /**
+   * Reads the first value of the configured SAML attribute from the brokered identity context.
+   * Extracted as a protected method to allow overriding in tests without requiring SAML DOM types.
+   *
+   * @param context the brokered identity context
+   * @param mapperModel the mapper configuration model
+   * @return the attribute value, or {@code null} if not found
+   */
+  protected String readAttribute(
+      final BrokeredIdentityContext context,
+      final IdentityProviderMapperModel mapperModel) {
+
+    final String attrName = mapperModel.getConfig().get(SAML_ATTRIBUTE_NAME);
+    final String friendlyName = mapperModel.getConfig().get(SAML_ATTRIBUTE_FRIENDLY_NAME);
+    final String lookupName = (attrName != null && !attrName.isBlank()) ? attrName : friendlyName;
+    if (lookupName == null || lookupName.isBlank()) {
+      return null;
+    }
+
+    final AssertionType assertion =
+        (AssertionType) context.getContextData().get(SAMLEndpoint.SAML_ASSERTION);
+    if (assertion == null) {
+      return null;
+    }
+
+    return assertion.getAttributeStatements().stream()
+        .flatMap(stmt -> stmt.getAttributes().stream())
+        .map(AttributeStatementType.ASTChoiceType::getAttribute)
+        .filter(attr -> Objects.equals(attr.getName(), lookupName)
+            || Objects.equals(attr.getFriendlyName(), lookupName))
+        .flatMap(attr -> attr.getAttributeValue().stream())
+        .filter(Objects::nonNull)
+        .map(Object::toString)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Resolves the effective session note key from the mapper model config, falling back to
+   * {@link #DEFAULT_SESSION_NOTE} when the config entry is absent or blank.
+   *
+   * @param mapperModel the mapper configuration model
+   * @return the session note key to use
+   */
+  static String resolveNoteKey(final IdentityProviderMapperModel mapperModel) {
+    final String key = mapperModel.getConfig().get(SESSION_NOTE_CONFIG);
+    return (key != null && !key.isBlank()) ? key : DEFAULT_SESSION_NOTE;
+  }
+
+}

--- a/saml-session-note-mapper/src/main/java/se/swedenconnect/keycloak/transientidp/SessionNoteClaimMapper.java
+++ b/saml-session-note-mapper/src/main/java/se/swedenconnect/keycloak/transientidp/SessionNoteClaimMapper.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.transientidp;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
+import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.IDToken;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An OIDC protocol mapper that reads a user session note and emits its value as a configurable
+ * token claim.
+ *
+ * <p>This mapper is the downstream counterpart of {@link SamlSessionNoteMapper}. Configure it on
+ * the OIDC client in the transient realm that issues tokens to the broker realm (e.g. orgiam).
+ * It reads the note written by {@link SamlSessionNoteMapper} and emits it as a standard OIDC
+ * claim so that the broker realm can use the value as a stable {@code identity_provider_identity}
+ * via {@code principalType=ATTRIBUTE}.</p>
+ *
+ * <p>Default values for Sweden Connect personal identity numbers:</p>
+ * <ul>
+ *   <li>Session note key: {@value SamlSessionNoteMapper#DEFAULT_SESSION_NOTE}</li>
+ *   <li>Claim name: {@value #DEFAULT_CLAIM_NAME} (dot-free to avoid Keycloak path-split issues)</li>
+ * </ul>
+ *
+ * @author David Goldring
+ */
+public class SessionNoteClaimMapper extends AbstractOIDCProtocolMapper
+    implements OIDCIDTokenMapper, OIDCAccessTokenMapper, UserInfoTokenMapper {
+
+  private static final Logger LOG = Logger.getLogger(SessionNoteClaimMapper.class);
+
+  /** Provider ID used to reference this mapper in Keycloak configuration. */
+  public static final String PROVIDER_ID = "transient-session-note-claim-mapper";
+
+  /** Configuration key for the user session note name to read. */
+  public static final String SESSION_NOTE_CONFIG = "session.note";
+
+  /**
+   * Default OIDC claim name emitted by this mapper for the personal identity number.
+   *
+   * <p>A simple name without dots is used deliberately. Keycloak's {@code splitClaimPath}
+   * splits claim names on unescaped dots when writing to the token, but the OIDC IdP's
+   * {@code getJsonProperty} does a flat key lookup when reading {@code principalAttribute}.
+   * Using a dot-free name avoids any mismatch between the two sides of the claim path.</p>
+   *
+   * <p>This claim is internal to the Transient→orgiam hop. The public-facing Sweden Connect
+   * claim ({@code https://id.oidc.se/claim/personalIdentityNumber}) is emitted by a separate
+   * mapper on the downstream orgiam client.</p>
+   */
+  public static final String DEFAULT_CLAIM_NAME = "personalIdentityNumber";
+
+  private static final List<ProviderConfigProperty> CONFIG_PROPERTIES;
+
+  static {
+    final List<ProviderConfigProperty> props = new ArrayList<>();
+
+    final ProviderConfigProperty sessionNoteProp = new ProviderConfigProperty();
+    sessionNoteProp.setName(SESSION_NOTE_CONFIG);
+    sessionNoteProp.setLabel("User Session Note");
+    sessionNoteProp.setHelpText(
+        "Name of the note in UserSessionModel.getNote() to read. "
+            + "Must match the note key configured on the \"SAML Attribute to Session Note\" "
+            + "identity provider mapper on the upstream SAML identity provider(s).");
+    sessionNoteProp.setType(ProviderConfigProperty.STRING_TYPE);
+    sessionNoteProp.setDefaultValue(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE);
+    props.add(sessionNoteProp);
+
+    OIDCAttributeMapperHelper.addAttributeConfig(props, SessionNoteClaimMapper.class);
+    props.stream()
+        .filter(p -> OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME.equals(p.getName()))
+        .findFirst()
+        .ifPresent(p -> p.setDefaultValue(DEFAULT_CLAIM_NAME));
+
+    CONFIG_PROPERTIES = Collections.unmodifiableList(props);
+  }
+
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
+
+  @Override
+  public String getDisplayType() {
+    return "Session Note to Claim";
+  }
+
+  @Override
+  public String getDisplayCategory() {
+    return AbstractOIDCProtocolMapper.TOKEN_MAPPER_CATEGORY;
+  }
+
+  @Override
+  public String getHelpText() {
+    return "Reads a user session note and emits its value as a configurable OIDC token claim. "
+        + "Pair with the \"SAML Attribute to Session Note\" identity provider mapper in a "
+        + "transient (doNotStoreUsers=true) proxy realm to propagate SAML assertion attributes "
+        + "into downstream OIDC tokens without persisting personal data in the transient realm. "
+        + "Use a dot-free claim name (e.g. \"personalIdentityNumber\") and configure the same "
+        + "name as the principalAttribute on the downstream broker identity provider. "
+        + "Avoid URL-style claim names with dots — Keycloak's path splitting and the IdP's "
+        + "flat claim lookup are inconsistent for dot-containing names.";
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return CONFIG_PROPERTIES;
+  }
+
+  @Override
+  protected void setClaim(
+      final IDToken token,
+      final ProtocolMapperModel mappingModel,
+      final UserSessionModel userSession,
+      final KeycloakSession keycloakSession,
+      final ClientSessionContext clientSessionCtx) {
+
+    final String noteKey = resolveNoteKey(mappingModel);
+    String value = userSession.getNote(noteKey);
+
+    if (value == null || value.isBlank()) {
+      // Fallback: read from the user model attribute. For lightweight (doNotStoreUsers=true)
+      // users in some Keycloak versions, auth-session user-session-notes are not reliably
+      // transferred to the UserSessionModel note map. The LightweightUserAdapter's attributes
+      //  are, however, serialized into the keycloak.userModel session note and remain accessible
+      // via getUser().getFirstAttribute(). SamlSessionNoteMapper.importNewUser/updateBrokeredUser
+      // sets the attribute under the same key to enable this fallback.
+      value = userSession.getUser().getFirstAttribute(noteKey);
+    }
+
+    if (value == null || value.isBlank()) {
+      LOG.debugf("Session note '%s' absent in user session and no matching user attribute — "
+          + "claim not added to token", noteKey);
+      return;
+    }
+
+    OIDCAttributeMapperHelper.mapClaim(token, mappingModel, value);
+    LOG.debugf("Mapped session note/attribute '%s' to token claim", noteKey);
+  }
+
+  /**
+   * Resolves the effective session note key from the mapper model config, falling back to
+   * {@link SamlSessionNoteMapper#DEFAULT_SESSION_NOTE} when the config entry is absent or blank.
+   *
+   * @param mappingModel the mapper configuration model
+   * @return the session note key to use
+   */
+  static String resolveNoteKey(final ProtocolMapperModel mappingModel) {
+    final String key = mappingModel.getConfig().get(SESSION_NOTE_CONFIG);
+    return (key != null && !key.isBlank()) ? key : SamlSessionNoteMapper.DEFAULT_SESSION_NOTE;
+  }
+
+}

--- a/saml-session-note-mapper/src/main/java/se/swedenconnect/keycloak/transientidp/package-info.java
+++ b/saml-session-note-mapper/src/main/java/se/swedenconnect/keycloak/transientidp/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+/**
+ * Mappers for propagating stable identity through transient proxy realms.
+ *
+ * @author David Goldring
+ */
+package se.swedenconnect.keycloak.transientidp;

--- a/saml-session-note-mapper/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/saml-session-note-mapper/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -1,0 +1,2 @@
+se.swedenconnect.keycloak.transientidp.SamlSessionNoteMapper
+se.swedenconnect.keycloak.transientidp.OidcClaimToBrokerIdMapper

--- a/saml-session-note-mapper/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/saml-session-note-mapper/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -1,0 +1,1 @@
+se.swedenconnect.keycloak.transientidp.SessionNoteClaimMapper

--- a/saml-session-note-mapper/src/test/java/se/swedenconnect/keycloak/transientidp/OidcClaimToBrokerIdMapperTest.java
+++ b/saml-session-note-mapper/src/test/java/se/swedenconnect/keycloak/transientidp/OidcClaimToBrokerIdMapperTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.transientidp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.JsonWebToken;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link OidcClaimToBrokerIdMapper}.
+ *
+ * @author David Goldring
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OidcClaimToBrokerIdMapperTest {
+
+  @Mock
+  private IdentityProviderMapperModel mapperModel;
+
+  @Mock
+  private BrokeredIdentityContext context;
+
+  @Mock
+  private IdentityProviderModel idpConfig;
+
+  @Mock
+  private KeycloakSession session;
+
+  @Mock
+  private RealmModel realm;
+
+  @Mock
+  private UserModel user;
+
+  private OidcClaimToBrokerIdMapper mapper;
+  private Map<String, Object> contextData;
+
+  @BeforeEach
+  void setUp() {
+    this.mapper = new OidcClaimToBrokerIdMapper();
+    this.contextData = new HashMap<>();
+    when(this.context.getContextData()).thenReturn(this.contextData);
+    when(this.context.getIdpConfig()).thenReturn(this.idpConfig);
+    when(this.idpConfig.getAlias()).thenReturn("orgiam.realm");
+  }
+
+  @Test
+  void claimPresent_setsId() {
+    when(this.mapperModel.getConfig()).thenReturn(
+        config(OidcClaimToBrokerIdMapper.CLAIM_NAME_CONFIG, "personalIdentityNumber"));
+    this.contextData.put(OIDCIdentityProvider.VALIDATED_ID_TOKEN,
+        tokenWithClaim("personalIdentityNumber", "191212121212"));
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.context).setId("191212121212");
+    verify(this.context).setUsername("191212121212");
+  }
+
+  @Test
+  void claimAbsent_doesNotSetIdOrUsername() {
+    when(this.mapperModel.getConfig()).thenReturn(
+        config(OidcClaimToBrokerIdMapper.CLAIM_NAME_CONFIG, "personalIdentityNumber"));
+    this.contextData.put(OIDCIdentityProvider.VALIDATED_ID_TOKEN, new JsonWebToken());
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.context, never()).setId(any());
+    verify(this.context, never()).setUsername(any());
+  }
+
+  @Test
+  void claimBlank_doesNotSetIdOrUsername() {
+    when(this.mapperModel.getConfig()).thenReturn(
+        config(OidcClaimToBrokerIdMapper.CLAIM_NAME_CONFIG, "personalIdentityNumber"));
+    this.contextData.put(OIDCIdentityProvider.VALIDATED_ID_TOKEN,
+        tokenWithClaim("personalIdentityNumber", "  "));
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.context, never()).setId(any());
+    verify(this.context, never()).setUsername(any());
+  }
+
+  @Test
+  void noValidatedIdToken_doesNotSetIdOrUsername() {
+    when(this.mapperModel.getConfig()).thenReturn(
+        config(OidcClaimToBrokerIdMapper.CLAIM_NAME_CONFIG, "personalIdentityNumber"));
+    // contextData left empty — no VALIDATED_ID_TOKEN entry
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.context, never()).setId(any());
+    verify(this.context, never()).setUsername(any());
+  }
+
+  @Test
+  void updateBrokeredUser_delegatesToPreprocessFederatedIdentity() {
+    when(this.mapperModel.getConfig()).thenReturn(
+        config(OidcClaimToBrokerIdMapper.CLAIM_NAME_CONFIG, "personalIdentityNumber"));
+    this.contextData.put(OIDCIdentityProvider.VALIDATED_ID_TOKEN,
+        tokenWithClaim("personalIdentityNumber", "197309069289"));
+
+    this.mapper.updateBrokeredUser(this.session, this.realm, this.user, this.mapperModel, this.context);
+
+    verify(this.context).setId("197309069289");
+    verify(this.context).setUsername("197309069289");
+  }
+
+  @Test
+  void customClaimName_readsFromCustomClaim() {
+    when(this.mapperModel.getConfig()).thenReturn(
+        config(OidcClaimToBrokerIdMapper.CLAIM_NAME_CONFIG, "pnr"));
+    this.contextData.put(OIDCIdentityProvider.VALIDATED_ID_TOKEN,
+        tokenWithClaim("pnr", "196408233234"));
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.context).setId("196408233234");
+    verify(this.context).setUsername("196408233234");
+  }
+
+  @Test
+  void resolveClaimName_configuredKey_returnsKey() {
+    when(this.mapperModel.getConfig()).thenReturn(
+        config(OidcClaimToBrokerIdMapper.CLAIM_NAME_CONFIG, "myCustomClaim"));
+
+    assertEquals("myCustomClaim", OidcClaimToBrokerIdMapper.resolveClaimName(this.mapperModel));
+  }
+
+  @Test
+  void resolveClaimName_nullKey_returnsDefault() {
+    when(this.mapperModel.getConfig()).thenReturn(new HashMap<>());
+
+    assertEquals(OidcClaimToBrokerIdMapper.DEFAULT_CLAIM_NAME,
+        OidcClaimToBrokerIdMapper.resolveClaimName(this.mapperModel));
+  }
+
+  @Test
+  void resolveClaimName_blankKey_returnsDefault() {
+    when(this.mapperModel.getConfig()).thenReturn(
+        config(OidcClaimToBrokerIdMapper.CLAIM_NAME_CONFIG, "  "));
+
+    assertEquals(OidcClaimToBrokerIdMapper.DEFAULT_CLAIM_NAME,
+        OidcClaimToBrokerIdMapper.resolveClaimName(this.mapperModel));
+  }
+
+  @Test
+  void getId_returnsProviderId() {
+    assertEquals(OidcClaimToBrokerIdMapper.PROVIDER_ID, this.mapper.getId());
+  }
+
+  // --- helpers ---
+
+  private static JsonWebToken tokenWithClaim(final String claimName, final String value) {
+    final JsonWebToken token = new JsonWebToken();
+    token.getOtherClaims().put(claimName, value);
+    return token;
+  }
+
+  private static Map<String, String> config(final String... keyValues) {
+    final Map<String, String> map = new HashMap<>();
+    for (int i = 0; i < keyValues.length - 1; i += 2) {
+      map.put(keyValues[i], keyValues[i + 1]);
+    }
+    return map;
+  }
+
+}

--- a/saml-session-note-mapper/src/test/java/se/swedenconnect/keycloak/transientidp/SamlSessionNoteMapperTest.java
+++ b/saml-session-note-mapper/src/test/java/se/swedenconnect/keycloak/transientidp/SamlSessionNoteMapperTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.transientidp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SamlSessionNoteMapper}.
+ *
+ * @author David Goldring
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SamlSessionNoteMapperTest {
+
+  @Mock
+  private KeycloakSession session;
+
+  @Mock
+  private RealmModel realm;
+
+  @Mock
+  private IdentityProviderMapperModel mapperModel;
+
+  @Mock
+  private BrokeredIdentityContext context;
+
+  @Mock
+  private AuthenticationSessionModel authSession;
+
+  @Mock
+  private IdentityProviderModel idpConfig;
+
+  private SamlSessionNoteMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    this.mapper = spy(new SamlSessionNoteMapper());
+    when(this.context.getAuthenticationSession()).thenReturn(this.authSession);
+    when(this.context.getIdpConfig()).thenReturn(this.idpConfig);
+    when(this.idpConfig.getAlias()).thenReturn("BankID");
+  }
+
+  @Test
+  void pinFound_storedAsDefaultSessionNote() {
+    when(this.mapperModel.getConfig()).thenReturn(config(
+        SamlSessionNoteMapper.SAML_ATTRIBUTE_NAME, "urn:oid:1.2.752.29.4.13"));
+    doReturn("191212121212").when(this.mapper).readAttribute(this.context, this.mapperModel);
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.authSession).setUserSessionNote(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE, "191212121212");
+  }
+
+  @Test
+  void pinFound_storedAsCustomSessionNote() {
+    when(this.mapperModel.getConfig()).thenReturn(config(
+        SamlSessionNoteMapper.SAML_ATTRIBUTE_NAME, "urn:oid:1.2.752.29.4.13",
+        SamlSessionNoteMapper.SESSION_NOTE_CONFIG, "my_custom_note"));
+    doReturn("197309069289").when(this.mapper).readAttribute(this.context, this.mapperModel);
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.authSession).setUserSessionNote("my_custom_note", "197309069289");
+  }
+
+  @Test
+  void attributeNotFound_noSessionNoteWritten() {
+    when(this.mapperModel.getConfig()).thenReturn(config(
+        SamlSessionNoteMapper.SAML_ATTRIBUTE_NAME, "urn:oid:1.2.752.29.4.13"));
+    doReturn(null).when(this.mapper).readAttribute(this.context, this.mapperModel);
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.authSession, never()).setUserSessionNote(any(), any());
+  }
+
+  @Test
+  void attributeBlank_noSessionNoteWritten() {
+    when(this.mapperModel.getConfig()).thenReturn(config(
+        SamlSessionNoteMapper.SAML_ATTRIBUTE_NAME, "urn:oid:1.2.752.29.4.13"));
+    doReturn("  ").when(this.mapper).readAttribute(this.context, this.mapperModel);
+
+    this.mapper.preprocessFederatedIdentity(this.session, this.realm, this.mapperModel, this.context);
+
+    verify(this.authSession, never()).setUserSessionNote(any(), any());
+  }
+
+  @Test
+  void resolveNoteKey_configuredKey_returnsConfiguredKey() {
+    when(this.mapperModel.getConfig()).thenReturn(config(
+        SamlSessionNoteMapper.SESSION_NOTE_CONFIG, "custom_key"));
+
+    assertEquals("custom_key", SamlSessionNoteMapper.resolveNoteKey(this.mapperModel));
+  }
+
+  @Test
+  void resolveNoteKey_nullKey_returnsDefault() {
+    when(this.mapperModel.getConfig()).thenReturn(new HashMap<>());
+
+    assertEquals(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE,
+        SamlSessionNoteMapper.resolveNoteKey(this.mapperModel));
+  }
+
+  @Test
+  void resolveNoteKey_blankKey_returnsDefault() {
+    when(this.mapperModel.getConfig()).thenReturn(config(
+        SamlSessionNoteMapper.SESSION_NOTE_CONFIG, "   "));
+
+    assertEquals(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE,
+        SamlSessionNoteMapper.resolveNoteKey(this.mapperModel));
+  }
+
+  @Test
+  void getId_returnsExpectedId() {
+    assertEquals(SamlSessionNoteMapper.PROVIDER_ID, this.mapper.getId());
+  }
+
+  @Test
+  void getConfigProperties_includesSessionNoteProperty() {
+    final boolean hasSessionNote = this.mapper.getConfigProperties().stream()
+        .anyMatch(p -> SamlSessionNoteMapper.SESSION_NOTE_CONFIG.equals(p.getName()));
+    assertTrue(hasSessionNote);
+  }
+
+  @Test
+  void getConfigProperties_includesSamlAttributeNameProperty() {
+    final boolean hasAttributeName = this.mapper.getConfigProperties().stream()
+        .anyMatch(p -> SamlSessionNoteMapper.SAML_ATTRIBUTE_NAME.equals(p.getName()));
+    assertTrue(hasAttributeName);
+  }
+
+  // --- helpers ---
+
+  private static Map<String, String> config(final String... keyValues) {
+    final Map<String, String> map = new HashMap<>();
+    for (int i = 0; i < keyValues.length - 1; i += 2) {
+      map.put(keyValues[i], keyValues[i + 1]);
+    }
+    return map;
+  }
+
+}

--- a/saml-session-note-mapper/src/test/java/se/swedenconnect/keycloak/transientidp/SessionNoteClaimMapperTest.java
+++ b/saml-session-note-mapper/src/test/java/se/swedenconnect/keycloak/transientidp/SessionNoteClaimMapperTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.keycloak.transientidp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.representations.IDToken;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SessionNoteClaimMapper}.
+ *
+ * @author David Goldring
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SessionNoteClaimMapperTest {
+
+  @Mock
+  private ProtocolMapperModel mappingModel;
+
+  @Mock
+  private UserSessionModel userSession;
+
+  @Mock
+  private UserModel user;
+
+  @Mock
+  private KeycloakSession keycloakSession;
+
+  @Mock
+  private ClientSessionContext clientSessionCtx;
+
+  private SessionNoteClaimMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    this.mapper = new SessionNoteClaimMapper();
+    when(this.userSession.getUser()).thenReturn(this.user);
+  }
+
+  @Test
+  void notePresent_claimAddedToToken() {
+    when(this.mappingModel.getConfig()).thenReturn(config(
+        SessionNoteClaimMapper.SESSION_NOTE_CONFIG, SamlSessionNoteMapper.DEFAULT_SESSION_NOTE,
+        "claim.name", SessionNoteClaimMapper.DEFAULT_CLAIM_NAME,
+        "jsonType.label", "String",
+        "id.token.claim", "true",
+        "access.token.claim", "false",
+        "userinfo.token.claim", "false"));
+    when(this.userSession.getNote(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE)).thenReturn("191212121212");
+
+    final IDToken token = new IDToken();
+    this.mapper.setClaim(token, this.mappingModel, this.userSession, this.keycloakSession, this.clientSessionCtx);
+
+    assertEquals("191212121212",
+        token.getOtherClaims().get(SessionNoteClaimMapper.DEFAULT_CLAIM_NAME));
+  }
+
+  @Test
+  void noteAbsent_claimNotAdded() {
+    when(this.mappingModel.getConfig()).thenReturn(config(
+        SessionNoteClaimMapper.SESSION_NOTE_CONFIG, SamlSessionNoteMapper.DEFAULT_SESSION_NOTE,
+        "claim.name", SessionNoteClaimMapper.DEFAULT_CLAIM_NAME,
+        "jsonType.label", "String",
+        "id.token.claim", "true"));
+    when(this.userSession.getNote(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE)).thenReturn(null);
+
+    final IDToken token = new IDToken();
+    this.mapper.setClaim(token, this.mappingModel, this.userSession, this.keycloakSession, this.clientSessionCtx);
+
+    assertFalse(token.getOtherClaims().containsKey(SessionNoteClaimMapper.DEFAULT_CLAIM_NAME));
+  }
+
+  @Test
+  void noteBlank_claimNotAdded() {
+    when(this.mappingModel.getConfig()).thenReturn(config(
+        SessionNoteClaimMapper.SESSION_NOTE_CONFIG, SamlSessionNoteMapper.DEFAULT_SESSION_NOTE,
+        "claim.name", SessionNoteClaimMapper.DEFAULT_CLAIM_NAME,
+        "jsonType.label", "String",
+        "id.token.claim", "true"));
+    when(this.userSession.getNote(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE)).thenReturn("  ");
+
+    final IDToken token = new IDToken();
+    this.mapper.setClaim(token, this.mappingModel, this.userSession, this.keycloakSession, this.clientSessionCtx);
+
+    assertFalse(token.getOtherClaims().containsKey(SessionNoteClaimMapper.DEFAULT_CLAIM_NAME));
+  }
+
+  @Test
+  void customNoteKey_readsFromCustomKey() {
+    when(this.mappingModel.getConfig()).thenReturn(config(
+        SessionNoteClaimMapper.SESSION_NOTE_CONFIG, "my_note",
+        "claim.name", "pnr",
+        "jsonType.label", "String",
+        "id.token.claim", "true",
+        "access.token.claim", "false",
+        "userinfo.token.claim", "false"));
+    when(this.userSession.getNote("my_note")).thenReturn("197309069289");
+
+    final IDToken token = new IDToken();
+    this.mapper.setClaim(token, this.mappingModel, this.userSession, this.keycloakSession, this.clientSessionCtx);
+
+    assertEquals("197309069289", token.getOtherClaims().get("pnr"));
+  }
+
+  @Test
+  void resolveNoteKey_configuredKey_returnsConfiguredKey() {
+    when(this.mappingModel.getConfig()).thenReturn(config(
+        SessionNoteClaimMapper.SESSION_NOTE_CONFIG, "configured_note"));
+
+    assertEquals("configured_note", SessionNoteClaimMapper.resolveNoteKey(this.mappingModel));
+  }
+
+  @Test
+  void resolveNoteKey_nullKey_returnsDefault() {
+    when(this.mappingModel.getConfig()).thenReturn(new HashMap<>());
+
+    assertEquals(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE,
+        SessionNoteClaimMapper.resolveNoteKey(this.mappingModel));
+  }
+
+  @Test
+  void resolveNoteKey_blankKey_returnsDefault() {
+    when(this.mappingModel.getConfig()).thenReturn(config(
+        SessionNoteClaimMapper.SESSION_NOTE_CONFIG, "  "));
+
+    assertEquals(SamlSessionNoteMapper.DEFAULT_SESSION_NOTE,
+        SessionNoteClaimMapper.resolveNoteKey(this.mappingModel));
+  }
+
+  @Test
+  void getId_returnsExpectedId() {
+    assertEquals(SessionNoteClaimMapper.PROVIDER_ID, this.mapper.getId());
+  }
+
+  @Test
+  void getConfigProperties_includesSessionNoteProperty() {
+    final boolean hasSessionNote = this.mapper.getConfigProperties().stream()
+        .anyMatch(p -> SessionNoteClaimMapper.SESSION_NOTE_CONFIG.equals(p.getName()));
+    assertTrue(hasSessionNote);
+  }
+
+  // --- helpers ---
+
+  private static Map<String, String> config(final String... keyValues) {
+    final Map<String, String> map = new HashMap<>();
+    for (int i = 0; i < keyValues.length - 1; i += 2) {
+      map.put(keyValues[i], keyValues[i + 1]);
+    }
+    return map;
+  }
+
+}


### PR DESCRIPTION
idp-hint-oidc-provider — Custom OIDC identity provider that forwards kc_idp_hint from the broker button-click URL to the upstream realm's authorization request. 
Solves single-page IdP selection in two-realm brokering chains where the hint is set on the login page rather than the initial client request.

saml-session-note-mapper — Three-mapper pipeline for propagating a stable Swedish personnummer through a transient proxy realm (doNotStoreUsers=true) to prevent ModelDuplicateException on second logins:

• SamlSessionNoteMapper — reads SAML assertion attribute → user session note
• SessionNoteClaimMapper — emits session note as OIDC claim
• OidcClaimToBrokerIdMapper — overrides broker identity ID with the stable claim

Checkstyle copyright regex updated to accept 2026 headers alongside existing 2025 ones